### PR TITLE
Fix issue blocking core31 package being used in .NET core 3.1 projects

### DIFF
--- a/src/TeeSquare.WebApi.Core31/TeeSquare.WebApi.Core31.csproj
+++ b/src/TeeSquare.WebApi.Core31/TeeSquare.WebApi.Core31.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -10,8 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0"/>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The below packages references aren't correct because they for .NET core
2.2 packages which don't have equivalent .NET core 3.1 package versions
(Microsoft stopped publishing packages for them).

* Microsoft.AspNetCore.Mvc.Core
* Microsoft.AspNetCore.Mvc.ViewFeatures

The correct way to reference types formerly in these packages is now to
add a Microsoft.AspNetCore.App shared framework library reference.

Reference:
https://docs.microsoft.com/en-us/aspnet/core/fundamentals/target-aspnetcore?view=aspnetcore-3.1&tabs=visual-studio#use-the-aspnet-core-shared-framework